### PR TITLE
Eclipse 2026-03 compatibility #73

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,7 +30,7 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
         # Tycho only supports LTS, other Java releases only short-term.
         # Tycho 3 no longer supports building on JDK 11, because it contains Java 17 class files.
-        java: [ 17 ]
+        java: [ 21 ]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -75,7 +75,7 @@ jobs:
       # Always run build without tests first
 
       - name: Build + package (no tests)
-        run: ./mvnw --batch-mode -Pe431 -DskipTests clean verify
+        run: ./mvnw --batch-mode -Pe439 -DskipTests clean verify
 
       # Then optionally run tests in one of 3 user-selected modes
       # TODO: find a way to avoid duplication
@@ -85,28 +85,28 @@ jobs:
         # UI tests need frame buffer on Linux
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: ./mvnw --batch-mode -Pe431 verify
+          run: ./mvnw --batch-mode -Pe439 verify
 
       - name: Run more tests, fail at end
         if: ${{ github.event.inputs.testMode == 'run more tests, fail at end' }}
         # UI tests need frame buffer on Linux
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: ./mvnw --batch-mode -Pe431 --fail-at-end verify
+          run: ./mvnw --batch-mode -Pe439 --fail-at-end verify
 
       - name: Run all tests, ignore failures
         if: ${{ github.event.inputs.testMode == 'run all tests, ignore failures' }}
         # UI tests need frame buffer on Linux
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: ./mvnw --batch-mode -Pe431 -Dmaven.test.failure.ignore=true verify
+          run: ./mvnw --batch-mode -Pe439 -Dmaven.test.failure.ignore=true verify
 
       # No matter if a preceding test run failed or not, try to generate and upload a test report
       # TODO: these steps should only happen if at least the build without tests passed, not always
 
       - name: Generate aggregate test report
         if: always()
-        run: ./mvnw --batch-mode -Pe431 -Daggregate=true surefire-report:report-only
+        run: ./mvnw --batch-mode -Pe439 -Daggregate=true surefire-report:report-only
 
       - name: Attach aggregate test report to build
         if: always()

--- a/org.eclipse.ajdt.core.tests/pom.xml
+++ b/org.eclipse.ajdt.core.tests/pom.xml
@@ -109,7 +109,6 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
-					<executionEnvironment>JavaSE-17</executionEnvironment>
 					<dependency-resolution>
 						<extraRequirements>
 							<requirement>

--- a/org.eclipse.ajdt.core/src/org/eclipse/ajdt/core/parserbridge/AJCompilationUnitStructureRequestor.java
+++ b/org.eclipse.ajdt.core/src/org/eclipse/ajdt/core/parserbridge/AJCompilationUnitStructureRequestor.java
@@ -136,6 +136,18 @@ public class AJCompilationUnitStructureRequestor extends
         setJDTParser(otherParser);
     }
 
+    @Override
+    public void enterBlock(int sourceEnd) {
+        // do nothing, this method is needed to resolve a default method conflict
+        // between org.eclipse.jdt.internal.compiler.ISourceElementRequestor and org.aspectj.org.eclipse.jdt.internal.compiler.ISourceElementRequestor
+    }
+
+    @Override
+    public void exitBlock(int sourceEnd) {
+        // do nothing, this method is needed to resolve a default method conflict
+        // between org.eclipse.jdt.internal.compiler.ISourceElementRequestor and org.aspectj.org.eclipse.jdt.internal.compiler.ISourceElementRequestor
+    }
+
     private void setJDTParser(org.eclipse.jdt.internal.compiler.parser.Parser parser) {
         this.parser = parser;
     }
@@ -287,11 +299,6 @@ public class AJCompilationUnitStructureRequestor extends
                     mi.isAnnotation,
                     mi.typeParameters,
                     mdecl);
-    }
-
-    @Override
-    public void exitCompactConstructor(int declarationEnd) {
-        super.exitCompactConstructor(declarationEnd);
     }
 
     /* default */ static String[] convertTypeNamesToSigsCopy(char[][] typeNames) {

--- a/org.eclipse.ajdt.core/src/org/eclipse/ajdt/core/parserbridge/AJSourceElementParser2.java
+++ b/org.eclipse.ajdt.core/src/org/eclipse/ajdt/core/parserbridge/AJSourceElementParser2.java
@@ -341,11 +341,12 @@ protected void consumeClassInstanceCreationExpressionWithTypeArguments() {
 			alloc.sourceStart);
 	}
 }
-protected void consumeConstructorHeaderName() {
+@Override
+protected void consumeConstructorHeaderName(boolean isCompact) {
 	long selectorSourcePositions = this.identifierPositionStack[this.identifierPtr];
 	int selectorSourceEnd = (int) selectorSourcePositions;
 	int currentAstPtr = this.astPtr;
-	super.consumeConstructorHeaderName();
+	super.consumeConstructorHeaderName(isCompact);
 	if (this.astPtr > currentAstPtr) { // if ast node was pushed on the ast stack
 		this.sourceEnds.put(this.astStack[this.astPtr], selectorSourceEnd);
 		rememberCategories();
@@ -423,8 +424,9 @@ protected void consumeFieldAccess(boolean isSuperAccess) {
 		requestor.acceptFieldReference(fr.token, fr.sourceStart);
 	}
 }
-protected void consumeFormalParameter(boolean isVarArgs) {
-	super.consumeFormalParameter(isVarArgs);
+@Override
+protected void consumeSingleVariableDeclarator(boolean isVarArgs) {
+	super.consumeSingleVariableDeclarator(isVarArgs);
 
 	// Flush comments prior to this formal parameter so the declarationSourceStart of the following parameter
 	// is correctly set (see bug 80904)
@@ -605,13 +607,6 @@ protected void consumeSingleStaticImportDeclarationName() {
 	//this.endPosition is just before the ;
 	impt.declarationSourceStart = this.intStack[this.intPtr--];
 
-	if(!this.statementRecoveryActivated &&
-			this.options.sourceLevel < ClassFileConstants.JDK1_5 &&
-			this.lastErrorEndPositionBeforeRecovery < this.scanner.currentPosition) {
-		impt.modifiers = ClassFileConstants.AccDefault; // convert the static import reference to a non-static importe reference
-		this.problemReporter().invalidUsageOfStaticImports(impt);
-	}
-
 	// recovery
 	if (this.currentElement != null){
 		this.lastCheckPoint = impt.declarationSourceEnd+1;
@@ -700,12 +695,6 @@ protected void consumeStaticImportOnDemandDeclarationName() {
 	//this.endPosition is just before the ;
 	impt.declarationSourceStart = this.intStack[this.intPtr--];
 
-	if(!this.statementRecoveryActivated &&
-			options.sourceLevel < ClassFileConstants.JDK1_5 &&
-			this.lastErrorEndPositionBeforeRecovery < this.scanner.currentPosition) {
-		impt.modifiers = ClassFileConstants.AccDefault; // convert the static import reference to a non-static importe reference
-		this.problemReporter().invalidUsageOfStaticImports(impt);
-	}
 
 	// recovery
 	if (this.currentElement != null){
@@ -771,7 +760,8 @@ protected CompilationUnitDeclaration endParse(int act) {
 		return null;
 	}
 }
-public TypeReference getTypeReference(int dim) {
+@Override
+public TypeReference constructTypeReference(int dim) {
 	/* build a Reference on a variable that may be qualified or not
 	 * This variable is a type reference and dim will be its dimensions
 	 */

--- a/org.eclipse.ajdt.core/src/org/eclipse/ajdt/core/parserbridge/AJSourceElementParser2.java
+++ b/org.eclipse.ajdt.core/src/org/eclipse/ajdt/core/parserbridge/AJSourceElementParser2.java
@@ -58,6 +58,7 @@ import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.impl.ReferenceContext;
 import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
+import org.eclipse.jdt.internal.compiler.parser.TerminalToken;
 import org.eclipse.jdt.internal.compiler.problem.AbortCompilation;
 import org.eclipse.jdt.internal.compiler.problem.ProblemReporter;
 import org.eclipse.jdt.internal.compiler.util.HashtableOfObjectToInt;
@@ -362,7 +363,7 @@ protected void consumeConstructorHeaderNameWithTypeParameters() {
 }
 protected void consumeEnumConstantWithClassBody() {
 	super.consumeEnumConstantWithClassBody();
-	if ((currentToken == TokenNameCOMMA || currentToken == TokenNameSEMICOLON)
+	if ((currentToken == TerminalToken.TokenNameCOMMA || currentToken == TerminalToken.TokenNameSEMICOLON)
 			&& astStack[astPtr] instanceof FieldDeclaration) {
 		this.sourceEnds.put(this.astStack[this.astPtr], this.scanner.currentPosition - 1);
 		rememberCategories();
@@ -370,7 +371,7 @@ protected void consumeEnumConstantWithClassBody() {
 }
 protected void consumeEnumConstantNoClassBody() {
 	super.consumeEnumConstantNoClassBody();
-	if ((currentToken == TokenNameCOMMA || currentToken == TokenNameSEMICOLON)
+	if ((currentToken == TerminalToken.TokenNameCOMMA || currentToken == TerminalToken.TokenNameSEMICOLON)
 			&& this.astStack[this.astPtr] instanceof FieldDeclaration) {
 		this.sourceEnds.put(this.astStack[this.astPtr], this.scanner.currentPosition - 1);
 		rememberCategories();
@@ -393,7 +394,7 @@ protected void consumeExitVariableWithInitialization() {
 	// the scanner is located after the comma or the semi-colon.
 	// we want to include the comma or the semi-colon
 	super.consumeExitVariableWithInitialization();
-	if ((currentToken == TokenNameCOMMA || currentToken == TokenNameSEMICOLON)
+	if ((currentToken == TerminalToken.TokenNameCOMMA || currentToken == TerminalToken.TokenNameSEMICOLON)
 			&& this.astStack[this.astPtr] instanceof FieldDeclaration) {
 		this.sourceEnds.put(this.astStack[this.astPtr], this.scanner.currentPosition - 1);
 		rememberCategories();
@@ -403,7 +404,7 @@ protected void consumeExitVariableWithoutInitialization() {
 	// ExitVariableWithoutInitialization ::= $empty
 	// do nothing by default
 	super.consumeExitVariableWithoutInitialization();
-	if ((currentToken == TokenNameCOMMA || currentToken == TokenNameSEMICOLON)
+	if ((currentToken == TerminalToken.TokenNameCOMMA || currentToken == TerminalToken.TokenNameSEMICOLON)
 			&& astStack[astPtr] instanceof FieldDeclaration) {
 		this.sourceEnds.put(this.astStack[this.astPtr], this.scanner.currentPosition - 1);
 		rememberCategories();
@@ -595,7 +596,7 @@ protected void consumeSingleStaticImportDeclarationName() {
 	this.modifiers = ClassFileConstants.AccDefault;
 	this.modifiersSourceStart = -1; // <-- see comment into modifiersFlag(int)
 
-	if (this.currentToken == TokenNameSEMICOLON){
+	if (this.currentToken == TerminalToken.TokenNameSEMICOLON){
 		impt.declarationSourceEnd = this.scanner.currentPosition - 1;
 	} else {
 		impt.declarationSourceEnd = impt.sourceEnd;
@@ -615,7 +616,7 @@ protected void consumeSingleStaticImportDeclarationName() {
 	if (this.currentElement != null){
 		this.lastCheckPoint = impt.declarationSourceEnd+1;
 		this.currentElement = this.currentElement.add(impt, 0);
-		this.lastIgnoredToken = -1;
+		this.lastIgnoredToken = TerminalToken.TokenNameInvalid;
 		this.restartRecovery = true; // used to avoid branching back into the regular automaton
 	}
 	if (reportReferenceInfo) {
@@ -653,7 +654,7 @@ protected void consumeSingleTypeImportDeclarationName() {
 	System.arraycopy(this.identifierPositionStack, this.identifierPtr + 1, positions, 0, length);
 	pushOnAstStack(impt = newImportReference(tokens, positions, false, ClassFileConstants.AccDefault));
 
-	if (this.currentToken == TokenNameSEMICOLON){
+	if (this.currentToken == TerminalToken.TokenNameSEMICOLON){
 		impt.declarationSourceEnd = this.scanner.currentPosition - 1;
 	} else {
 		impt.declarationSourceEnd = impt.sourceEnd;
@@ -666,7 +667,7 @@ protected void consumeSingleTypeImportDeclarationName() {
 	if (this.currentElement != null){
 		this.lastCheckPoint = impt.declarationSourceEnd+1;
 		this.currentElement = this.currentElement.add(impt, 0);
-		this.lastIgnoredToken = -1;
+		this.lastIgnoredToken = TerminalToken.TokenNameInvalid;
 		this.restartRecovery = true; // used to avoid branching back into the regular automaton
 	}
 	if (reportReferenceInfo) {
@@ -690,7 +691,7 @@ protected void consumeStaticImportOnDemandDeclarationName() {
 	this.modifiers = ClassFileConstants.AccDefault;
 	this.modifiersSourceStart = -1; // <-- see comment into modifiersFlag(int)
 
-	if (this.currentToken == TokenNameSEMICOLON){
+	if (this.currentToken == TerminalToken.TokenNameSEMICOLON){
 		impt.declarationSourceEnd = this.scanner.currentPosition - 1;
 	} else {
 		impt.declarationSourceEnd = impt.sourceEnd;
@@ -710,7 +711,7 @@ protected void consumeStaticImportOnDemandDeclarationName() {
 	if (this.currentElement != null){
 		this.lastCheckPoint = impt.declarationSourceEnd+1;
 		this.currentElement = this.currentElement.add(impt, 0);
-		this.lastIgnoredToken = -1;
+		this.lastIgnoredToken = TerminalToken.TokenNameInvalid;
 		this.restartRecovery = true; // used to avoid branching back into the regular automaton
 	}
 	if (reportReferenceInfo) {
@@ -732,7 +733,7 @@ protected void consumeTypeImportOnDemandDeclarationName() {
 	pushOnAstStack(impt = new ImportReference(tokens, positions, true, ClassFileConstants.AccDefault));
 
     impt.trailingStarPosition = this.intStack[this.intPtr--];
-	if (this.currentToken == TokenNameSEMICOLON){
+	if (this.currentToken == TerminalToken.TokenNameSEMICOLON){
 		impt.declarationSourceEnd = this.scanner.currentPosition - 1;
 	} else {
 		impt.declarationSourceEnd = impt.sourceEnd;
@@ -745,7 +746,7 @@ protected void consumeTypeImportOnDemandDeclarationName() {
 	if (this.currentElement != null){
 		this.lastCheckPoint = impt.declarationSourceEnd+1;
 		this.currentElement = this.currentElement.add(impt, 0);
-		this.lastIgnoredToken = -1;
+		this.lastIgnoredToken = TerminalToken.TokenNameInvalid;
 		this.restartRecovery = true; // used to avoid branching back into the regular automaton
 	}
 	if (reportReferenceInfo) {

--- a/org.eclipse.ajdt.ui.tests/pom.xml
+++ b/org.eclipse.ajdt.ui.tests/pom.xml
@@ -110,7 +110,6 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
-					<executionEnvironment>JavaSE-17</executionEnvironment>
 					<dependency-resolution>
 						<extraRequirements>
 							<requirement>

--- a/org.eclipse.ajdt.ui/jdt-src/org/eclipse/ajdt/internal/ui/dialogs/TypeSelectionComponent.java
+++ b/org.eclipse.ajdt.ui/jdt-src/org/eclipse/ajdt/internal/ui/dialogs/TypeSelectionComponent.java
@@ -329,7 +329,6 @@ public class TypeSelectionComponent extends Composite implements ITypeSelectionC
 		fToolBar.setLayoutData(data);
 
 		fToolItem.setImage(JavaPluginImages.get(JavaPluginImages.IMG_ELCL_VIEW_MENU));
-		fToolItem.setDisabledImage(JavaPluginImages.get(JavaPluginImages.IMG_DLCL_VIEW_MENU));
 		fToolItem.setToolTipText(JavaUIMessages.TypeSelectionComponent_menu);
 		fToolItem.addSelectionListener(new SelectionAdapter() {
 			public void widgetSelected(SelectionEvent e) {

--- a/org.eclipse.ajdt.ui/src/org/eclipse/ajdt/internal/buildpath/ConfigureAJBuildPathAction.java
+++ b/org.eclipse.ajdt.ui/src/org/eclipse/ajdt/internal/buildpath/ConfigureAJBuildPathAction.java
@@ -38,7 +38,6 @@ public class ConfigureAJBuildPathAction extends Action implements
 				NewWizardMessages.NewSourceContainerWorkbookPage_ToolBar_ConfigureBP_label,
 				JavaPluginImages.DESC_ELCL_CONFIGURE_BUILDPATH);
 		setToolTipText(NewWizardMessages.NewSourceContainerWorkbookPage_ToolBar_ConfigureBP_tooltip);
-		setDisabledImageDescriptor(JavaPluginImages.DESC_DLCL_CONFIGURE_BUILDPATH);
 	}
 
 	private Shell getShell() {

--- a/org.eclipse.ajdt.ui/src/org/eclipse/ajdt/internal/ui/editor/actions/AJOrganizeImportsOperation.java
+++ b/org.eclipse.ajdt.ui/src/org/eclipse/ajdt/internal/ui/editor/actions/AJOrganizeImportsOperation.java
@@ -97,7 +97,7 @@ public class AJOrganizeImportsOperation implements IWorkspaceRunnable {
 
 			public UnresolvedTypeData(SimpleName ref) {
 				this.ref= ref;
-				this.typeKinds= ASTResolving.getPossibleTypeKinds(ref, true);
+				this.typeKinds= ASTResolving.getPossibleTypeKinds(ref);
 				this.foundInfos= new ArrayList<>(3);
 			}
 

--- a/org.eclipse.ajdt.ui/src/org/eclipse/ajdt/internal/ui/editor/quickfix/UnresolvedElementsSubProcessor.java
+++ b/org.eclipse.ajdt.ui/src/org/eclipse/ajdt/internal/ui/editor/quickfix/UnresolvedElementsSubProcessor.java
@@ -66,6 +66,7 @@ import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+import org.eclipse.jdt.core.manipulation.CUCorrectionProposalCore;
 import org.eclipse.jdt.core.manipulation.TypeKinds;
 //import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility;
 import org.eclipse.jdt.internal.core.manipulation.StubUtility;
@@ -86,7 +87,7 @@ import org.eclipse.jdt.internal.ui.text.correction.SimilarElement;
 import org.eclipse.jdt.internal.ui.text.correction.SimilarElementsRequestor;
 import org.eclipse.jdt.internal.ui.text.correction.TypeMismatchSubProcessor;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.AddArgumentCorrectionProposal;
-import org.eclipse.jdt.internal.ui.text.correction.proposals.AddImportCorrectionProposal;
+import org.eclipse.jdt.internal.ui.text.correction.proposals.AddImportCorrectionProposalCore;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.AddTypeParameterProposal;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.CastCorrectionProposal;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.ChangeMethodSignatureProposal;
@@ -109,6 +110,7 @@ import org.eclipse.jdt.ui.JavaElementLabels;
 import org.eclipse.jdt.ui.text.java.IInvocationContext;
 import org.eclipse.jdt.ui.text.java.IProblemLocation;
 import org.eclipse.jdt.ui.text.java.correction.ASTRewriteCorrectionProposal;
+import org.eclipse.jdt.ui.text.java.correction.ASTRewriteCorrectionProposalCore;
 import org.eclipse.jdt.ui.text.java.correction.CUCorrectionProposal;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.ISharedImages;
@@ -521,7 +523,7 @@ public class UnresolvedElementsSubProcessor {
 	}
 
 	private static int evauateTypeKind(ASTNode node, IJavaProject project) {
-    return ASTResolving.getPossibleTypeKinds(node, true);
+    return ASTResolving.getPossibleTypeKinds(node);
 	}
 
 
@@ -589,9 +591,9 @@ public class UnresolvedElementsSubProcessor {
 			simpleBinding= simpleBinding.getTypeDeclaration();
 
 			resolvedTypeName= simpleBinding.getQualifiedName();
-			CUCorrectionProposal proposal= createTypeRefChangeProposal(cu, resolvedTypeName, node, relevance + 2, elements.length);
+			CUCorrectionProposalCore proposal= createTypeRefChangeProposal(cu, resolvedTypeName, node, relevance + 2, elements.length);
 			proposals.add(proposal);
-			if (proposal instanceof AddImportCorrectionProposal)
+			if (proposal instanceof AddImportCorrectionProposalCore)
 				proposal.setRelevance(relevance + elements.length + 2);
 
 			if (binding.isParameterizedType() && node.getParent() instanceof SimpleType && !(node.getParent().getParent() instanceof Type)) {
@@ -618,7 +620,7 @@ public class UnresolvedElementsSubProcessor {
     }
 	}
 
-	private static CUCorrectionProposal createTypeRefChangeProposal(ICompilationUnit cu, String fullName, Name node, int relevance, int maxProposals) throws CoreException {
+	private static CUCorrectionProposalCore createTypeRefChangeProposal(ICompilationUnit cu, String fullName, Name node, int relevance, int maxProposals) throws CoreException {
 		ImportRewrite importRewrite= null;
 		String simpleName= fullName;
 		String packName= Signature.getQualifier(fullName);
@@ -631,14 +633,13 @@ public class UnresolvedElementsSubProcessor {
 			relevance -= 2;
 		}
 
-		ASTRewriteCorrectionProposal proposal;
+		ASTRewriteCorrectionProposalCore proposal;
 		if (importRewrite != null && node.isSimpleName() && simpleName.equals(((SimpleName) node).getIdentifier())) { // import only
 			// import only
 			String[] arg= { simpleName, packName };
 			String label= Messages.format(CorrectionMessages.UnresolvedElementsSubProcessor_importtype_description, arg);
-			Image image= JavaPluginImages.get(JavaPluginImages.IMG_OBJS_IMPDECL);
 			int boost= QualifiedTypeNameHistory.getBoost(fullName, 0, maxProposals);
-			proposal= new AddImportCorrectionProposal(label, cu, relevance + 100 + boost, image, packName, simpleName, (SimpleName)node);
+			proposal= new AddImportCorrectionProposalCore(label, cu, relevance + 100 + boost, packName, simpleName, (SimpleName)node);
 			proposal.setCommandId(ADD_IMPORT_ID);
 		} else {
 			String label;
@@ -650,8 +651,7 @@ public class UnresolvedElementsSubProcessor {
 			}
 			ASTRewrite rewrite= ASTRewrite.create(node.getAST());
 			rewrite.replace(node, rewrite.createStringPlaceholder(simpleName, ASTNode.SIMPLE_TYPE), null);
-			Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
-			proposal= new ASTRewriteCorrectionProposal(label, cu, rewrite, relevance, image);
+			proposal= new ASTRewriteCorrectionProposalCore(label, cu, rewrite, relevance);
 		}
 		if (importRewrite != null) {
 			proposal.setImportRewrite(importRewrite);

--- a/org.eclipse.ajdt.ui/src/org/eclipse/ajdt/internal/ui/tracing/ClearEventTraceAction.java
+++ b/org.eclipse.ajdt.ui/src/org/eclipse/ajdt/internal/ui/tracing/ClearEventTraceAction.java
@@ -45,10 +45,8 @@ public class ClearEventTraceAction extends Action {
 		setToolTipText(ConsoleMessages.ClearOutputAction_toolTipText);
 		setHoverImageDescriptor(ConsolePluginImages
 				.getImageDescriptor(IConsoleConstants.IMG_LCL_CLEAR));
-		setDisabledImageDescriptor(ConsolePluginImages
-				.getImageDescriptor(IInternalConsoleConstants.IMG_DLCL_CLEAR));
 		setImageDescriptor(ConsolePluginImages
-				.getImageDescriptor(IInternalConsoleConstants.IMG_ELCL_CLEAR));
+				.getImageDescriptor(IConsoleConstants.IMG_LCL_CLEAR));
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(this,
 				IConsoleHelpContextIds.CLEAR_CONSOLE_ACTION);
 	}

--- a/org.eclipse.ajdt.ui/src/org/eclipse/ajdt/internal/ui/tracing/FilterTraceAction.java
+++ b/org.eclipse.ajdt.ui/src/org/eclipse/ajdt/internal/ui/tracing/FilterTraceAction.java
@@ -77,7 +77,6 @@ public class FilterTraceAction extends Action {
 		ShowFilterDialogAction() {
 			setText(XRefMessages.OpenCustomFiltersDialogAction_text);
 			setImageDescriptor(JavaPluginImages.DESC_ELCL_FILTER);
-			setDisabledImageDescriptor(JavaPluginImages.DESC_DLCL_FILTER);
 		}
 
 		public void run() {

--- a/org.eclipse.ajdt.ui/src/org/eclipse/ajdt/internal/utils/AJDTUtils.java
+++ b/org.eclipse.ajdt.ui/src/org/eclipse/ajdt/internal/utils/AJDTUtils.java
@@ -14,6 +14,8 @@
  **********************************************************************/
 package org.eclipse.ajdt.internal.utils;
 
+import static org.eclipse.ajdt.internal.utils.PdeInternals.isPluginProject;
+
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -72,7 +74,6 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.pde.core.plugin.IPluginImport;
 import org.eclipse.pde.core.plugin.IPluginModel;
-import org.eclipse.pde.internal.core.natures.PDE;
 import org.eclipse.pde.internal.ui.IPDEUIConstants;
 import org.eclipse.pde.internal.ui.editor.plugin.DependenciesPage;
 import org.eclipse.pde.internal.ui.editor.plugin.ManifestEditor;
@@ -190,7 +191,7 @@ public class AJDTUtils {
         // Bugzilla 62625
         // Bugzilla 93532 - just add plugin dependency if there is a plugin.xml file
         // Bugzilla 137922 - also consider bundles without a plugin.xml
-        if (project.hasNature(PDE.PLUGIN_NATURE)
+        if (isPluginProject(project)
                 && (hasPluginManifest(project)
                         || hasBundleManifest(project))) {
             // Dealing with a plugin project. In that case the
@@ -643,7 +644,7 @@ public class AJDTUtils {
         // Bugzilla 62625
         // Bugzilla 93532 - just remove plugin dependency if there is a plugin.xml file
         // Bugzilla 137922 - also consider bundles without a plugin.xml
-        if (project.hasNature(PDE.PLUGIN_NATURE)
+        if (isPluginProject(project)
                 && (hasPluginManifest(project)
                         || hasBundleManifest(project))) {
             // Bugzilla 72007

--- a/org.eclipse.ajdt.ui/src/org/eclipse/ajdt/internal/utils/PdeInternals.java
+++ b/org.eclipse.ajdt.ui/src/org/eclipse/ajdt/internal/utils/PdeInternals.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Xored Software Inc and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     Xored Software Inc - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.ajdt.internal.utils;
+
+import org.eclipse.core.resources.IProject;
+
+public final class PdeInternals {
+    private PdeInternals() {}
+    public static boolean isPluginProject(IProject project) {
+    	return org.eclipse.pde.internal.core.natures.PluginProject.isPluginProject(project);
+    }
+}

--- a/org.eclipse.contribution.visualiser.tests/pom.xml
+++ b/org.eclipse.contribution.visualiser.tests/pom.xml
@@ -37,7 +37,6 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
-					<executionEnvironment>JavaSE-17</executionEnvironment>
 					<dependency-resolution>
 						<extraRequirements>
 							<requirement>

--- a/org.eclipse.contribution.weaving.jdt.tests/pom.xml
+++ b/org.eclipse.contribution.weaving.jdt.tests/pom.xml
@@ -68,7 +68,6 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
-					<executionEnvironment>JavaSE-17</executionEnvironment>
 					<dependency-resolution>
 						<extraRequirements>
 							<requirement>

--- a/org.eclipse.contribution.weaving.jdt/schema/cuprovider.exsd
+++ b/org.eclipse.contribution.weaving.jdt/schema/cuprovider.exsd
@@ -2,9 +2,9 @@
 <!-- Schema file written by PDE -->
 <schema targetNamespace="org.eclipse.contribution.weaving.jdt" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
-      <appinfo>
+      <appInfo>
          <meta.schema plugin="org.eclipse.contribution.weaving.jdt" id="cuprovider" name="Compilation Unit Provider"/>
-      </appinfo>
+      </appInfo>
       <documentation>
          Provides an alternate implementation of org.eclipse.jdt.internal.core.CompilationUnit based on file extension.
       </documentation>
@@ -12,9 +12,9 @@
 
    <element name="extension">
       <annotation>
-         <appinfo>
+         <appInfo>
             <meta.element />
-         </appinfo>
+         </appInfo>
       </annotation>
       <complexType>
          <sequence minOccurs="1" maxOccurs="unbounded">
@@ -39,9 +39,9 @@
                <documentation>
                   
                </documentation>
-               <appinfo>
+               <appInfo>
                   <meta.attribute translatable="true"/>
-               </appinfo>
+               </appInfo>
             </annotation>
          </attribute>
       </complexType>
@@ -59,9 +59,9 @@
                <documentation>
                   
                </documentation>
-               <appinfo>
+               <appInfo>
                   <meta.attribute kind="java" basedOn=":org.eclipse.contribution.jdt.cuprovider.ICompilationUnitProvider"/>
-               </appinfo>
+               </appInfo>
             </annotation>
          </attribute>
          <attribute name="file_extension" type="string" use="required">
@@ -75,36 +75,36 @@
    </element>
 
    <annotation>
-      <appinfo>
+      <appInfo>
          <meta.section type="since"/>
-      </appinfo>
+      </appInfo>
       <documentation>
          1.6.2
       </documentation>
    </annotation>
 
    <annotation>
-      <appinfo>
+      <appInfo>
          <meta.section type="examples"/>
-      </appinfo>
+      </appInfo>
       <documentation>
          [Enter extension point usage example here.]
       </documentation>
    </annotation>
 
    <annotation>
-      <appinfo>
+      <appInfo>
          <meta.section type="apiinfo"/>
-      </appinfo>
+      </appInfo>
       <documentation>
          [Enter API information here.]
       </documentation>
    </annotation>
 
    <annotation>
-      <appinfo>
+      <appInfo>
          <meta.section type="implementation"/>
-      </appinfo>
+      </appInfo>
       <documentation>
          [Enter information about supplied implementation of this extension point.]
       </documentation>

--- a/org.eclipse.contribution.xref.core.tests/pom.xml
+++ b/org.eclipse.contribution.xref.core.tests/pom.xml
@@ -45,7 +45,6 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
-					<executionEnvironment>JavaSE-17</executionEnvironment>
 					<dependency-resolution>
 						<extraRequirements>
 							<requirement>

--- a/org.eclipse.contribution.xref.ui.tests/pom.xml
+++ b/org.eclipse.contribution.xref.ui.tests/pom.xml
@@ -57,7 +57,6 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
-					<executionEnvironment>JavaSE-17</executionEnvironment>
 					<dependency-resolution>
 						<extraRequirements>
 							<requirement>

--- a/org.eclipse.contribution.xref.ui/src/org/eclipse/contribution/xref/internal/ui/actions/XReferenceCustomFilterAction.java
+++ b/org.eclipse.contribution.xref.ui/src/org/eclipse/contribution/xref/internal/ui/actions/XReferenceCustomFilterAction.java
@@ -47,7 +47,6 @@ public class XReferenceCustomFilterAction extends Action {
 
 		setText(XRefMessages.OpenCustomFiltersDialogAction_text);
 		setImageDescriptor(JavaPluginImages.DESC_ELCL_FILTER);
-		setDisabledImageDescriptor(JavaPluginImages.DESC_DLCL_FILTER);
 
 		populatingList = new ArrayList<>();
 		checkedList = new ArrayList<>();

--- a/org.eclipse.contribution.xref.ui/src/org/eclipse/contribution/xref/internal/ui/actions/XReferenceCustomFilterActionInplace.java
+++ b/org.eclipse.contribution.xref.ui/src/org/eclipse/contribution/xref/internal/ui/actions/XReferenceCustomFilterActionInplace.java
@@ -47,7 +47,6 @@ public class XReferenceCustomFilterActionInplace extends Action {
 
 		setText(XRefMessages.OpenCustomFiltersDialogAction_text);
 		setImageDescriptor(JavaPluginImages.DESC_ELCL_FILTER);
-		setDisabledImageDescriptor(JavaPluginImages.DESC_DLCL_FILTER);
 
 		populatingList = new ArrayList<>();
 		checkedList = new ArrayList<>();

--- a/org.eclipse.contribution.xref.ui/src/org/eclipse/contribution/xref/internal/ui/inplace/XReferenceInplaceDialog.java
+++ b/org.eclipse.contribution.xref.ui/src/org/eclipse/contribution/xref/internal/ui/inplace/XReferenceInplaceDialog.java
@@ -495,8 +495,6 @@ public class XReferenceInplaceDialog {
 
 		viewMenuButton.setImage(JavaPluginImages
 				.get(JavaPluginImages.IMG_ELCL_VIEW_MENU));
-		viewMenuButton.setDisabledImage(JavaPluginImages
-				.get(JavaPluginImages.IMG_DLCL_VIEW_MENU));
 		viewMenuButton.setToolTipText(XRefMessages.XReferenceInplaceDialog_viewMenu_toolTipText);
 
 		//Used to enable the menu to be accessed from the keyboard

--- a/pom.xml
+++ b/pom.xml
@@ -302,6 +302,21 @@
 		</profile>
 
 		<profile>
+			<id>e439</id>
+			<properties>
+				<platform.version>e439</platform.version>
+				<weaving.hook.version>1.4.400.v20250628-0635</weaving.hook.version>
+			</properties>
+			<repositories>
+				<repository>
+					<id>2026-03-releases</id>
+					<layout>p2</layout>
+					<url>https://download.eclipse.org/releases/2026-03/</url>
+				</repository>
+			</repositories>
+		</profile>
+
+		<profile>
 			<!--
 				This profile enables an IDE like IntelliJ IDEA to resolve classes from aspectjrt, aspectjweaver, aspectjtools
 				directly, because the corresponding Maven modules creating OSGi components (org.aspectj.runtime,

--- a/pom.xml
+++ b/pom.xml
@@ -363,7 +363,6 @@
 						<artifactId>target-platform-configuration</artifactId>
 						<configuration>
 							<includePackedArtifacts>true</includePackedArtifacts>
-							<executionEnvironment>JavaSE-17</executionEnvironment>
 						</configuration>
 					</plugin>
 					<plugin>
@@ -407,7 +406,6 @@
 						<artifactId>target-platform-configuration</artifactId>
 						<configuration>
 							<includePackedArtifacts>true</includePackedArtifacts>
-							<executionEnvironment>JavaSE-17</executionEnvironment>
 						</configuration>
 					</plugin>
 					<plugin>
@@ -551,7 +549,7 @@
 							<arch>x86_64</arch>
 						</environment>
 					</environments>
-					<executionEnvironment>JavaSE-17</executionEnvironment>
+					<executionEnvironment>JavaSE-21</executionEnvironment>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
Fixes #73

This fixes incompatibility with modern JDT IDE (we fixed compatibility with modern Eclipse runtime in https://github.com/eclipse-aspectj/ajdt/pull/70)

Potential issues:
- disabled icons were removed following similar change in JDT. I have not tested the consequences.
- deleted `AJSourceElementParser2.consumeFormalParameter()` is replaced on a guess
- same for removed `ASTResolving.getPossibleTypeKinds()` boolean parameter

In general, I've tried to concentrate non-trivial fixes in the [second commit](https://github.com/eclipse-aspectj/ajdt/pull/76/changes/9c75a9fd1fd9a7008a144f7fb0f2dc9b5a828c04)

Requires a new deployment job that uses the new Maven profile (`-P e439` instead of [the old](https://ci.eclipse.org/aspectj/job/ajdt-on-eclipse-e431/) `-P e431`)