### PR TITLE
Bump AJDT version to 2.3.0 #77

### DIFF
--- a/org.aspectj-feature/pom.xml
+++ b/org.aspectj-feature/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.aspectj.ajde</groupId>

--- a/org.aspectj.ajde/pom.xml
+++ b/org.aspectj.ajde/pom.xml
@@ -14,7 +14,7 @@
   <parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.aspectj.ajde</groupId>

--- a/org.aspectj.runtime/pom.xml
+++ b/org.aspectj.runtime/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.aspectj.ajde</groupId>

--- a/org.aspectj.weaver/pom.xml
+++ b/org.aspectj.weaver/pom.xml
@@ -14,7 +14,7 @@
   <parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.aspectj.ajde</groupId>

--- a/org.eclipse.ajdt-feature/feature.xml
+++ b/org.eclipse.ajdt-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.ajdt"
       label="%featureName"
-      version="2.2.4.qualifier"
+      version="2.3.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.aspectj">
 

--- a/org.eclipse.ajdt-feature/pom.xml
+++ b/org.eclipse.ajdt-feature/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.ajdt</artifactId>

--- a/org.eclipse.ajdt.core.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.ajdt.core.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.ajdt.core.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: AJDT Core Tests Plug-in
 Bundle-SymbolicName: org.eclipse.ajdt.core.tests;singleton:=true
-Bundle-Version: 2.2.4.qualifier
+Bundle-Version: 2.3.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.ajdt.core.tests.AspectJCoreTestPlugin
 Bundle-Vendor: Eclipse AspectJ Development Tools

--- a/org.eclipse.ajdt.core.tests/pom.xml
+++ b/org.eclipse.ajdt.core.tests/pom.xml
@@ -12,13 +12,13 @@
     <dependency>
       <groupId>org.eclipse.ajdt</groupId>
       <artifactId>org.eclipse.ajdt.core</artifactId>
-      <version>2.2.4-SNAPSHOT</version>
+      <version>2.3.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.ajdt</groupId>
       <artifactId>org.eclipse.contribution.weaving.jdt</artifactId>
-      <version>2.2.4-SNAPSHOT</version>
+      <version>2.3.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>
@@ -26,7 +26,7 @@
   <parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.ajdt.core.tests</artifactId>

--- a/org.eclipse.ajdt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.ajdt.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.ajdt.core
 Bundle-ManifestVersion: 2
 Bundle-Name: AspectJ Development Tools Core
 Bundle-SymbolicName: org.eclipse.ajdt.core; singleton:=true
-Bundle-Version: 2.2.4.qualifier
+Bundle-Version: 2.3.0.qualifier
 Bundle-Activator: org.eclipse.ajdt.core.AspectJPlugin
 Bundle-Vendor: Eclipse AspectJ Development Tools
 Bundle-Localization: plugin

--- a/org.eclipse.ajdt.core/pom.xml
+++ b/org.eclipse.ajdt.core/pom.xml
@@ -12,7 +12,7 @@
     <dependency>
       <groupId>org.eclipse.ajdt</groupId>
       <artifactId>org.eclipse.contribution.weaving.jdt</artifactId>
-      <version>2.2.4-SNAPSHOT</version>
+      <version>2.3.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>
@@ -20,7 +20,7 @@
   <parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.ajdt.core</artifactId>

--- a/org.eclipse.ajdt.doc.user/META-INF/MANIFEST.MF
+++ b/org.eclipse.ajdt.doc.user/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: AspectJ Development Tools User Documentation
 Bundle-SymbolicName: org.eclipse.ajdt.doc.user;singleton:=true
-Bundle-Version: 2.2.4.qualifier
+Bundle-Version: 2.3.0.qualifier
 Bundle-Vendor: Eclipse AspectJ Development Tools
 Bundle-Localization: plugin

--- a/org.eclipse.ajdt.doc.user/pom.xml
+++ b/org.eclipse.ajdt.doc.user/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.ajdt.doc.user</artifactId>

--- a/org.eclipse.ajdt.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.ajdt.examples/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.ajdt.examples
 Bundle-ManifestVersion: 2
 Bundle-Name: AspectJ Examples
 Bundle-SymbolicName: org.eclipse.ajdt.examples; singleton:=true
-Bundle-Version: 2.2.4.qualifier
+Bundle-Version: 2.3.0.qualifier
 Bundle-ClassPath: ajdtExamples.jar
 Bundle-Activator: org.eclipse.ajdt.examples.AspectJExamplePlugin
 Bundle-Vendor: Eclipse AspectJ Development Tools

--- a/org.eclipse.ajdt.examples/pom.xml
+++ b/org.eclipse.ajdt.examples/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.ajdt.examples</artifactId>

--- a/org.eclipse.ajdt.releng/pom.xml
+++ b/org.eclipse.ajdt.releng/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.ajdt.releng</artifactId>

--- a/org.eclipse.ajdt.sdk-feature/feature.xml
+++ b/org.eclipse.ajdt.sdk-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.ajdt.sdk"
       label="%featureName"
-      version="2.2.4.qualifier"
+      version="2.3.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.aspectj">
 

--- a/org.eclipse.ajdt.sdk-feature/pom.xml
+++ b/org.eclipse.ajdt.sdk-feature/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.ajdt.sdk</artifactId>

--- a/org.eclipse.ajdt.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.ajdt.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.ajdt.ui.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: AJDT UI Tests Plug-in
 Bundle-SymbolicName: org.eclipse.ajdt.ui.tests;singleton:=true
-Bundle-Version: 2.2.4.qualifier
+Bundle-Version: 2.3.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.ajdt.ui.tests.AspectJTestPlugin
 Bundle-Vendor: Eclipse.org

--- a/org.eclipse.ajdt.ui.tests/pom.xml
+++ b/org.eclipse.ajdt.ui.tests/pom.xml
@@ -6,19 +6,19 @@
     <dependency>
       <groupId>org.eclipse.ajdt</groupId>
       <artifactId>org.eclipse.ajdt.core</artifactId>
-      <version>2.2.4-SNAPSHOT</version>
+      <version>2.3.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.ajdt</groupId>
       <artifactId>org.eclipse.ajdt.ui</artifactId>
-      <version>2.2.4-SNAPSHOT</version>
+      <version>2.3.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.ajdt</groupId>
       <artifactId>org.eclipse.ajdt.core.tests</artifactId>
-      <version>2.2.4-SNAPSHOT</version>
+      <version>2.3.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>
@@ -26,7 +26,7 @@
   <parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.ajdt.ui.tests</artifactId>

--- a/org.eclipse.ajdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.ajdt.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.ajdt.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: AspectJ Development Tools UI
 Bundle-SymbolicName: org.eclipse.ajdt.ui; singleton:=true
-Bundle-Version: 2.2.4.qualifier
+Bundle-Version: 2.3.0.qualifier
 Bundle-Activator: org.eclipse.ajdt.ui.AspectJUIPlugin
 Bundle-Vendor: Eclipse AspectJ Development Tools
 Bundle-Localization: plugin

--- a/org.eclipse.ajdt.ui/pom.xml
+++ b/org.eclipse.ajdt.ui/pom.xml
@@ -6,25 +6,25 @@
     <dependency>
       <groupId>org.eclipse.ajdt</groupId>
       <artifactId>org.eclipse.contribution.xref.core</artifactId>
-      <version>2.2.4-SNAPSHOT</version>
+      <version>2.3.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.ajdt</groupId>
       <artifactId>org.eclipse.ajdt.core</artifactId>
-      <version>2.2.4-SNAPSHOT</version>
+      <version>2.3.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.ajdt</groupId>
       <artifactId>org.eclipse.contribution.xref.ui</artifactId>
-      <version>2.2.4-SNAPSHOT</version>
+      <version>2.3.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.ajdt</groupId>
       <artifactId>org.eclipse.contribution.visualiser</artifactId>
-      <version>2.2.4-SNAPSHOT</version>
+      <version>2.3.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>
@@ -32,7 +32,7 @@
   <parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.ajdt.ui</artifactId>

--- a/org.eclipse.aspectj.feature_tests/feature.xml
+++ b/org.eclipse.aspectj.feature_tests/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.aspectj.feature_tests"
       label="%featureName"
-      version="2.2.4.qualifier"
+      version="2.3.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/org.eclipse.aspectj.feature_tests/pom.xml
+++ b/org.eclipse.aspectj.feature_tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.aspectj.feature_tests</artifactId>

--- a/org.eclipse.aspectj/META-INF/MANIFEST.MF
+++ b/org.eclipse.aspectj/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: AspectJ Development Tools
 Bundle-SymbolicName: org.eclipse.aspectj; singleton:=true
-Bundle-Version: 2.2.4.qualifier
+Bundle-Version: 2.3.0.qualifier
 Bundle-Vendor: Eclipse AspectJ Development Tools
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.aspectj/pom.xml
+++ b/org.eclipse.aspectj/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.aspectj</artifactId>

--- a/org.eclipse.contribution.visualiser.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.contribution.visualiser.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.contribution.visualiser.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: Visualser Tests
 Bundle-SymbolicName: org.eclipse.contribution.visualiser.tests;singleton:=true
-Bundle-Version: 2.2.4.qualifier
+Bundle-Version: 2.3.0.qualifier
 Bundle-ClassPath: .
 Export-Package: org.eclipse.contribution.visualiser.tests
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.contribution.visualiser.tests/pom.xml
+++ b/org.eclipse.contribution.visualiser.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.contribution.visualiser.tests</artifactId>

--- a/org.eclipse.contribution.visualiser/META-INF/MANIFEST.MF
+++ b/org.eclipse.contribution.visualiser/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.contribution.visualiser
 Bundle-ManifestVersion: 2
 Bundle-Name: Visualiser Plug-in
 Bundle-SymbolicName: org.eclipse.contribution.visualiser; singleton:=true
-Bundle-Version: 2.2.4.qualifier
+Bundle-Version: 2.3.0.qualifier
 Bundle-Activator: org.eclipse.contribution.visualiser.VisualiserPlugin
 Bundle-Vendor: Eclipse AspectJ Development Tools
 Bundle-Localization: plugin

--- a/org.eclipse.contribution.visualiser/pom.xml
+++ b/org.eclipse.contribution.visualiser/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.contribution.visualiser</artifactId>

--- a/org.eclipse.contribution.weaving-feature/feature.xml
+++ b/org.eclipse.contribution.weaving-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.contribution.weaving"
       label="%featureName"
-      version="2.2.4.qualifier"
+      version="2.3.0.qualifier"
       provider-name="%providerName">
 
    <description url="http://eclipse.org/ajdt">

--- a/org.eclipse.contribution.weaving-feature/pom.xml
+++ b/org.eclipse.contribution.weaving-feature/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.contribution.weaving</artifactId>

--- a/org.eclipse.contribution.weaving.jdt.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.contribution.weaving.jdt.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.contribution.weaving.jdt.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: JDT Weaving Tests
 Bundle-SymbolicName: org.eclipse.contribution.weaving.jdt.tests;singleton:=true
-Bundle-Version: 2.2.4.qualifier
+Bundle-Version: 2.3.0.qualifier
 Require-Bundle: org.eclipse.contribution.weaving.jdt;bundle-version="2.2.4",
  org.aspectj.runtime,
  org.eclipse.osgi;bundle-version="[3.5.0,4.3.0)",

--- a/org.eclipse.contribution.weaving.jdt.tests/pom.xml
+++ b/org.eclipse.contribution.weaving.jdt.tests/pom.xml
@@ -6,7 +6,7 @@
     <dependency>
       <groupId>org.eclipse.ajdt</groupId>
       <artifactId>org.eclipse.contribution.weaving.jdt</artifactId>
-      <version>2.2.4-SNAPSHOT</version>
+      <version>2.3.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>
@@ -14,7 +14,7 @@
   <parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.contribution.weaving.jdt.tests</artifactId>

--- a/org.eclipse.contribution.weaving.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.contribution.weaving.jdt/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.contribution.weaving.jdt
 Bundle-ManifestVersion: 2
 Bundle-Name: JDT Weaving
 Bundle-SymbolicName: org.eclipse.contribution.weaving.jdt;singleton:=true
-Bundle-Version: 2.2.4.qualifier
+Bundle-Version: 2.3.0.qualifier
 Require-Bundle: org.aspectj.runtime;bundle-version="1.9.25",
  org.eclipse.osgi;bundle-version="[3.6.0,4.3.0)",
  org.eclipse.core.runtime;bundle-version="[3.6.0,4.3.0)";visibility:=reexport,
@@ -22,18 +22,18 @@ Require-Bundle: org.aspectj.runtime;bundle-version="1.9.25",
  org.eclipse.jdt.debug;bundle-version="[3.6.0,4.3.0)",
  org.eclipse.jdt.launching;bundle-version="[3.6.0,4.3.0)"
 Bundle-Activator: org.eclipse.contribution.jdt.JDTWeavingPlugin
-Export-Package: org.eclipse.contribution.jdt;version="2.2.4";uses:="org.osgi.framework,org.eclipse.ui.plugin",
- org.eclipse.contribution.jdt.cuprovider;version="2.2.4";uses:="org.eclipse.jdt.core,org.eclipse.jdt.internal.core",
+Export-Package: org.eclipse.contribution.jdt;version="2.3.0";uses:="org.osgi.framework,org.eclipse.ui.plugin",
+ org.eclipse.contribution.jdt.cuprovider;version="2.3.0";uses:="org.eclipse.jdt.core,org.eclipse.jdt.internal.core",
  org.eclipse.contribution.jdt.debug,
- org.eclipse.contribution.jdt.imagedescriptor;version="2.2.4";uses:="org.eclipse.jdt.internal.ui.text.java,org.eclipse.jface.resource",
- org.eclipse.contribution.jdt.itdawareness;version="2.2.4";
+ org.eclipse.contribution.jdt.imagedescriptor;version="2.3.0";uses:="org.eclipse.jdt.internal.ui.text.java,org.eclipse.jface.resource",
+ org.eclipse.contribution.jdt.itdawareness;version="2.3.0";
   uses:="org.eclipse.jdt.internal.compiler.env,
    org.eclipse.jdt.core,
    org.eclipse.jdt.internal.core,
    org.eclipse.jdt.internal.compiler,
    org.eclipse.jdt.internal.compiler.ast,
    org.eclipse.core.runtime",
- org.eclipse.contribution.jdt.preferences;version="2.2.4";
+ org.eclipse.contribution.jdt.preferences;version="2.3.0";
   uses:="org.eclipse.jface.preference,
    org.eclipse.ui.progress,
    org.eclipse.core.resources,
@@ -41,8 +41,8 @@ Export-Package: org.eclipse.contribution.jdt;version="2.2.4";uses:="org.osgi.fra
    org.eclipse.core.runtime,
    org.eclipse.ui,
    org.eclipse.core.internal.events",
- org.eclipse.contribution.jdt.refactoring;version="2.2.4",
- org.eclipse.contribution.jdt.sourceprovider;version="2.2.4";uses:="org.eclipse.jdt.internal.compiler.env"
+ org.eclipse.contribution.jdt.refactoring;version="2.3.0",
+ org.eclipse.contribution.jdt.sourceprovider;version="2.3.0";uses:="org.eclipse.jdt.internal.compiler.env"
 Eclipse-SupplementBundle: org.eclipse.jdt.core,
  org.eclipse.jdt.ui,
  org.eclipse.jdt.junit.core,

--- a/org.eclipse.contribution.weaving.jdt/pom.xml
+++ b/org.eclipse.contribution.weaving.jdt/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.contribution.weaving.jdt</artifactId>

--- a/org.eclipse.contribution.xref-feature/feature.xml
+++ b/org.eclipse.contribution.xref-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.contribution.xref"
       label="%featureName"
-      version="2.2.4.qualifier"
+      version="2.3.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/org.eclipse.contribution.xref-feature/pom.xml
+++ b/org.eclipse.contribution.xref-feature/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.contribution.xref</artifactId>

--- a/org.eclipse.contribution.xref.core.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.contribution.xref.core.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.contribution.xref.core.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: Cross Reference Core Test Plugin
 Bundle-SymbolicName: org.eclipse.contribution.xref.core.tests; singleton:=true
-Bundle-Version: 2.2.4.qualifier
+Bundle-Version: 2.3.0.qualifier
 Bundle-ClassPath: xrefcoretests.jar
 Bundle-Vendor: Eclipse AspectJ Development Tools
 Bundle-Localization: plugin

--- a/org.eclipse.contribution.xref.core.tests/pom.xml
+++ b/org.eclipse.contribution.xref.core.tests/pom.xml
@@ -6,7 +6,7 @@
     <dependency>
       <groupId>org.eclipse.ajdt</groupId>
       <artifactId>org.eclipse.contribution.xref.core</artifactId>
-      <version>2.2.4-SNAPSHOT</version>
+      <version>2.3.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>
@@ -14,7 +14,7 @@
   <parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.contribution.xref.core.tests</artifactId>

--- a/org.eclipse.contribution.xref.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.contribution.xref.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.contribution.xref.core
 Bundle-ManifestVersion: 2
 Bundle-Name: Cross Reference Core Plugin
 Bundle-SymbolicName: org.eclipse.contribution.xref.core; singleton:=true
-Bundle-Version: 2.2.4.qualifier
+Bundle-Version: 2.3.0.qualifier
 Bundle-Activator: org.eclipse.contribution.xref.core.XReferencePlugin
 Bundle-Vendor: Eclipse AspectJ Development Tools
 Bundle-Localization: plugin

--- a/org.eclipse.contribution.xref.core/pom.xml
+++ b/org.eclipse.contribution.xref.core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.contribution.xref.core</artifactId>

--- a/org.eclipse.contribution.xref.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.contribution.xref.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.contribution.xref.ui.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: Cross Reference UI Test Plugin
 Bundle-SymbolicName: org.eclipse.contribution.xref.ui.tests; singleton:=true
-Bundle-Version: 2.2.4.qualifier
+Bundle-Version: 2.3.0.qualifier
 Bundle-ClassPath: xrefuitests.jar
 Bundle-Vendor: Eclipse AspectJ Development Tools
 Bundle-Localization: plugin

--- a/org.eclipse.contribution.xref.ui.tests/pom.xml
+++ b/org.eclipse.contribution.xref.ui.tests/pom.xml
@@ -6,19 +6,19 @@
     <dependency>
       <groupId>org.eclipse.ajdt</groupId>
       <artifactId>org.eclipse.contribution.xref.core</artifactId>
-      <version>2.2.4-SNAPSHOT</version>
+      <version>2.3.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.ajdt</groupId>
       <artifactId>org.eclipse.contribution.xref.core.tests</artifactId>
-      <version>2.2.4-SNAPSHOT</version>
+      <version>2.3.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.ajdt</groupId>
       <artifactId>org.eclipse.contribution.xref.ui</artifactId>
-      <version>2.2.4-SNAPSHOT</version>
+      <version>2.3.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>
@@ -26,7 +26,7 @@
   <parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.contribution.xref.ui.tests</artifactId>

--- a/org.eclipse.contribution.xref.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.contribution.xref.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.contribution.xref.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: Cross Reference UI Plugin
 Bundle-SymbolicName: org.eclipse.contribution.xref.ui; singleton:=true
-Bundle-Version: 2.2.4.qualifier
+Bundle-Version: 2.3.0.qualifier
 Bundle-Activator: org.eclipse.contribution.xref.ui.XReferenceUIPlugin
 Bundle-Vendor: Eclipse AspectJ Development Tools
 Bundle-Localization: plugin

--- a/org.eclipse.contribution.xref.ui/pom.xml
+++ b/org.eclipse.contribution.xref.ui/pom.xml
@@ -6,7 +6,7 @@
     <dependency>
       <groupId>org.eclipse.ajdt</groupId>
       <artifactId>org.eclipse.contribution.xref.core</artifactId>
-      <version>2.2.4-SNAPSHOT</version>
+      <version>2.3.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>
@@ -14,7 +14,7 @@
   <parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.contribution.xref.ui</artifactId>

--- a/org.eclipse.equinox.weaving.aspectj.tests/pom.xml
+++ b/org.eclipse.equinox.weaving.aspectj.tests/pom.xml
@@ -25,7 +25,7 @@ Stefan Winkler - initial implementation
 	<parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.equinox.weaving.aspectj.tests</artifactId>

--- a/org.eclipse.equinox.weaving.aspectj/pom.xml
+++ b/org.eclipse.equinox.weaving.aspectj/pom.xml
@@ -23,7 +23,7 @@ Igor Fedorenko - initial implementation
   <parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
   <artifactId>org.eclipse.equinox.weaving.aspectj</artifactId>

--- a/org.eclipse.equinox.weaving.sdk/pom.xml
+++ b/org.eclipse.equinox.weaving.sdk/pom.xml
@@ -14,7 +14,7 @@ Igor Fedorenko - initial implementation
 	<parent>
 		<groupId>org.eclipse.ajdt</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.2.4-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
   <artifactId>org.eclipse.equinox.weaving.sdk</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.eclipse.ajdt</groupId>
 	<artifactId>parent</artifactId>
-	<version>2.2.4-SNAPSHOT</version>
+	<version>2.3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>AJDT (AspectJ Development Tools)</name>


### PR DESCRIPTION
Done in preparation to publish new update site. See #77.

```
mvn tycho-versions:set-version -DnewVersion=2.3.0-SNAPSHOT
```